### PR TITLE
Fix storing persistent data

### DIFF
--- a/celery/worker/state.py
+++ b/celery/worker/state.py
@@ -225,14 +225,14 @@ class Persistent(object):
 
     def _merge_clock(self, d):
         if self.clock:
-            d['clock'] = self.clock.adjust(d.get('clock') or 0)
+            d[b'clock'] = self.clock.adjust(d.get(b'clock') or 0)
 
     def _merge_revoked(self, d):
         try:
-            self._merge_revoked_v3(d['zrevoked'])
+            self._merge_revoked_v3(d[b'zrevoked'])
         except KeyError:
             try:
-                self._merge_revoked_v2(d.pop('revoked'))
+                self._merge_revoked_v2(d.pop(b'revoked'))
             except KeyError:
                 pass
         # purge expired items at boot


### PR DESCRIPTION
## Description
I'm using Python 2. Worker starts OK if there is no --statedb param. But when I specify --statedb param I get the following error:
```
docker@stage:~$ /project/env/bin/celery worker -A project.celery_app -E -l INFO -n worker.high -Q high --statedb /project/tmp/celery/worker.high.state
Traceback (most recent call last):
  File "/project/env/bin/celery", line 11, in <module>
    sys.exit(main())
  File "/project/env/local/lib/python2.7/site-packages/celery/__main__.py", line 14, in main
    _main()
  File "/project/env/local/lib/python2.7/site-packages/celery/bin/celery.py", line 326, in main
    cmd.execute_from_commandline(argv)
  File "/project/env/local/lib/python2.7/site-packages/celery/bin/celery.py", line 488, in execute_from_commandline
    super(CeleryCommand, self).execute_from_commandline(argv)))
  File "/project/env/local/lib/python2.7/site-packages/celery/bin/base.py", line 278, in execute_from_commandline
    return self.handle_argv(self.prog_name, argv[1:])
  File "/project/env/local/lib/python2.7/site-packages/celery/bin/celery.py", line 480, in handle_argv
    return self.execute(command, argv)
  File "/project/env/local/lib/python2.7/site-packages/celery/bin/celery.py", line 412, in execute
    ).run_from_argv(self.prog_name, argv[1:], command=argv[0])
  File "/project/env/local/lib/python2.7/site-packages/celery/bin/worker.py", line 221, in run_from_argv
    return self(*args, **options)
  File "/project/env/local/lib/python2.7/site-packages/celery/bin/base.py", line 241, in __call__
    ret = self.run(*args, **kwargs)
  File "/project/env/local/lib/python2.7/site-packages/celery/bin/worker.py", line 255, in run
    **kwargs)
  File "/project/env/local/lib/python2.7/site-packages/celery/worker/worker.py", line 100, in __init__
    self.setup_instance(**self.prepare_args(**kwargs))
  File "/project/env/local/lib/python2.7/site-packages/celery/worker/worker.py", line 140, in setup_instance
    self.blueprint.apply(self, **kwargs)
  File "/project/env/local/lib/python2.7/site-packages/celery/bootsteps.py", line 214, in apply
    step.include(parent)
  File "/project/env/local/lib/python2.7/site-packages/celery/bootsteps.py", line 343, in include
    return self._should_include(parent)[0]
  File "/project/env/local/lib/python2.7/site-packages/celery/bootsteps.py", line 339, in _should_include
    return True, self.create(parent)
  File "/project/env/local/lib/python2.7/site-packages/celery/worker/components.py", line 214, in create
    w._persistence = w.state.Persistent(w.state, w.statedb, w.app.clock)
  File "/project/env/local/lib/python2.7/site-packages/celery/worker/state.py", line 189, in __init__
    self.merge()
  File "/project/env/local/lib/python2.7/site-packages/celery/worker/state.py", line 197, in merge
    self._merge_with(self.db)
  File "/project/env/local/lib/python2.7/site-packages/celery/worker/state.py", line 213, in _merge_with
    self._merge_revoked(d)
  File "/project/env/local/lib/python2.7/site-packages/celery/worker/state.py", line 232, in _merge_revoked
    self._merge_revoked_v3(d['zrevoked'])
  File "/usr/lib/python2.7/shelve.py", line 121, in __getitem__
    f = StringIO(self.dict[key])
  File "/usr/lib/python2.7/bsddb/__init__.py", line 270, in __getitem__
    return _DeadlockWrap(lambda: self.db[key])  # self.db[key]
  File "/usr/lib/python2.7/bsddb/dbutils.py", line 68, in DeadlockWrap
    return function(*_args, **_kwargs)
  File "/usr/lib/python2.7/bsddb/__init__.py", line 270, in <lambda>
    return _DeadlockWrap(lambda: self.db[key])  # self.db[key]
TypeError: String or Integer object expected for key, unicode found
```
So we should use bytes literals for keys in shelve storage for working in Python 2.